### PR TITLE
Add support for only monitoring sessions for specific users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ FROM alpine:latest
 
 ENV INTERVAL=900
 ENV REMAINING_EPISODES=2
+ENV USERS=
 
 COPY --from=builder /app/target/release/prefetcharr /
 
@@ -21,4 +22,5 @@ CMD ["sh", "-c", "./prefetcharr \
   --log-dir \"${LOG_DIR}\" \
   --interval \"${INTERVAL}\" \
   --remaining-episodes \"${REMAINING_EPISODES}\" \
+  --users \"${USERS}\" \
   "]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ services:
       - INTERVAL=900
       # The last <NUM> episodes trigger a search
       - REMAINING_EPISODES=2
+      # Only monitor sessions for specific user IDs or names
+      - USERS=john,12345,alex
     volumes:
       - /path/to/log/dir:/log
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,11 @@ struct Args {
     /// The last <NUM> episodes trigger a search
     #[arg(long, value_name = "NUM", default_value_t = 2)]
     remaining_episodes: u8,
+    /// User IDs or names to monitor episodes for (default: empty/all users)
+    ///
+    /// Each entry here is checked against the user's ID and name
+    #[arg(long, value_name = "USER", value_delimiter = ',', num_args = 0..)]
+    users: Vec<String>,
 }
 
 #[derive(Clone, Debug, ValueEnum)]
@@ -144,7 +149,8 @@ async fn run(args: Args) -> anyhow::Result<()> {
     };
 
     let seen = Seen::default();
-    let mut actor = process::Actor::new(rx, sonarr_client, seen, args.remaining_episodes);
+    let mut actor =
+        process::Actor::new(rx, sonarr_client, seen, args.remaining_episodes, args.users);
 
     tokio::join!(watcher, actor.process());
 

--- a/src/media_server.rs
+++ b/src/media_server.rs
@@ -19,6 +19,8 @@ pub struct NowPlaying {
     pub series: Series,
     pub episode: i32,
     pub season: i32,
+    pub user_id: String,
+    pub user_name: String,
 }
 
 pub trait MediaServer: Sized {

--- a/src/media_server/embyfin.rs
+++ b/src/media_server/embyfin.rs
@@ -41,6 +41,7 @@ struct Series {
 #[serde(rename_all = "PascalCase")]
 pub struct SessionInfo {
     user_id: String,
+    user_name: String,
     now_playing_item: Episode,
     #[serde(flatten)]
     other: serde_json::Value,
@@ -159,6 +160,8 @@ impl MediaServer for Client {
         session: Self::Session,
     ) -> std::prelude::v1::Result<NowPlaying, Self::Error> {
         let episode_num = session.now_playing_item.index_number;
+        let user_id = session.user_id.clone();
+        let user_name = session.user_name.clone();
         let ids = Ids::from(session);
 
         let series: Series = self.item(&ids.user, &ids.series).await?;
@@ -177,6 +180,8 @@ impl MediaServer for Client {
             series,
             episode: episode_num,
             season: season_num,
+            user_id,
+            user_name,
         };
 
         Ok(now_playing)
@@ -197,7 +202,8 @@ mod test {
     fn episode() -> serde_json::Value {
         serde_json::json!(
             [{
-                "UserId": "user",
+                "UserId": "08ba1929-681e-4b24-929b-9245852f65c0",
+                "UserName": "user",
                 "NowPlayingItem": {
                     "SeriesId": "a",
                     "SeasonId": "b",
@@ -226,14 +232,14 @@ mod test {
 
         let season_mock = server
             .mock_async(|when, then| {
-                when.path("/pathprefix/Users/user/Items/b");
+                when.path("/pathprefix/Users/08ba1929-681e-4b24-929b-9245852f65c0/Items/b");
                 then.json_body(serde_json::json!({"IndexNumber": 3}));
             })
             .await;
 
         let series_mock = server
             .mock_async(|when, then| {
-                when.path("/pathprefix/Users/user/Items/a");
+                when.path("/pathprefix/Users/08ba1929-681e-4b24-929b-9245852f65c0/Items/a");
                 then.json_body(series());
             })
             .await;
@@ -251,6 +257,8 @@ mod test {
             series: Series::Tvdb(1234),
             episode: 5,
             season: 3,
+            user_id: "08ba1929-681e-4b24-929b-9245852f65c0".to_string(),
+            user_name: "user".to_string(),
         });
 
         assert_eq!(message, Some(message_expect));
@@ -273,7 +281,8 @@ mod test {
                 then.json_body(serde_json::json!(
                     [{ "invalid": "session" },
                      {
-                        "UserId": "user",
+                        "UserId": "08ba1929-681e-4b24-929b-9245852f65c0",
+                        "UserName": "user",
                         "NowPlayingItem": {
                             "SeriesId": "invalid",
                             "SeasonId": "invalid",
@@ -281,7 +290,8 @@ mod test {
                         }
                      },
                      {
-                        "UserId": "user",
+                        "UserId": "08ba1929-681e-4b24-929b-9245852f65c0",
+                        "UserName": "user",
                         "NowPlayingItem": {
                             "SeriesId": "a",
                             "SeasonId": "b",
@@ -294,14 +304,14 @@ mod test {
 
         let season_mock = server
             .mock_async(|when, then| {
-                when.path("/pathprefix/Users/user/Items/b");
+                when.path("/pathprefix/Users/08ba1929-681e-4b24-929b-9245852f65c0/Items/b");
                 then.json_body(serde_json::json!({"IndexNumber": 3}));
             })
             .await;
 
         let series_mock = server
             .mock_async(|when, then| {
-                when.path("/pathprefix/Users/user/Items/a");
+                when.path("/pathprefix/Users/08ba1929-681e-4b24-929b-9245852f65c0/Items/a");
                 then.json_body(series());
             })
             .await;
@@ -319,6 +329,8 @@ mod test {
             series: Series::Tvdb(1234),
             episode: 5,
             season: 3,
+            user_id: "08ba1929-681e-4b24-929b-9245852f65c0".to_string(),
+            user_name: "user".to_string(),
         });
 
         assert_eq!(message, Some(message_expect));
@@ -344,14 +356,14 @@ mod test {
 
         let season_mock = server
             .mock_async(|when, then| {
-                when.path("/pathprefix/Users/user/Items/b");
+                when.path("/pathprefix/Users/08ba1929-681e-4b24-929b-9245852f65c0/Items/b");
                 then.json_body(serde_json::json!({"IndexNumber": 3}));
             })
             .await;
 
         let series_mock = server
             .mock_async(|when, then| {
-                when.path("/pathprefix/Users/user/Items/a");
+                when.path("/pathprefix/Users/08ba1929-681e-4b24-929b-9245852f65c0/Items/a");
                 then.json_body(serde_json::json!({
                     "Name": "Test Show",
                     "ProviderIds": { }
@@ -369,6 +381,8 @@ mod test {
             series: Series::Title("Test Show".to_string()),
             episode: 5,
             season: 3,
+            user_id: "08ba1929-681e-4b24-929b-9245852f65c0".to_string(),
+            user_name: "user".to_string(),
         });
 
         assert_eq!(message, Some(message_expect));
@@ -399,14 +413,14 @@ mod test {
 
         let _season_mock = server
             .mock_async(|when, then| {
-                when.path("/pathprefix/Users/user/Items/b");
+                when.path("/pathprefix/Users/08ba1929-681e-4b24-929b-9245852f65c0/Items/b");
                 then.json_body(serde_json::json!({"IndexNumber": 3}));
             })
             .await;
 
         let _series_mock = server
             .mock_async(|when, then| {
-                when.path("/pathprefix/Users/user/Items/a");
+                when.path("/pathprefix/Users/08ba1929-681e-4b24-929b-9245852f65c0/Items/a");
                 then.json_body(series());
             })
             .await;
@@ -443,14 +457,14 @@ mod test {
 
         let _season_mock = server
             .mock_async(|when, then| {
-                when.path("/pathprefix/Users/user/Items/b");
+                when.path("/pathprefix/Users/08ba1929-681e-4b24-929b-9245852f65c0/Items/b");
                 then.json_body(serde_json::json!({"IndexNumber": 3}));
             })
             .await;
 
         let _series_mock = server
             .mock_async(|when, then| {
-                when.path("/pathprefix/Users/user/Items/a");
+                when.path("/pathprefix/Users/08ba1929-681e-4b24-929b-9245852f65c0/Items/a");
                 then.json_body(series());
             })
             .await;
@@ -485,14 +499,14 @@ mod test {
 
         let _season_mock = server
             .mock_async(|when, then| {
-                when.path("/pathprefix/Users/user/Items/b");
+                when.path("/pathprefix/Users/08ba1929-681e-4b24-929b-9245852f65c0/Items/b");
                 then.json_body(serde_json::json!({"IndexNumber": 3}));
             })
             .await;
 
         let _series_mock = server
             .mock_async(|when, then| {
-                when.path("/pathprefix/Users/user/Items/a");
+                when.path("/pathprefix/Users/08ba1929-681e-4b24-929b-9245852f65c0/Items/a");
                 then.json_body(series());
             })
             .await;

--- a/src/media_server/plex.rs
+++ b/src/media_server/plex.rs
@@ -7,12 +7,22 @@ use super::{MediaServer, NowPlaying};
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct User {
+    id: String,
+    title: String,
+    #[serde(flatten)]
+    _other: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Episode {
     grandparent_title: String,
     grandparent_key: String,
     index: i32,
     parent_index: i32,
     r#type: String,
+    user: User,
     #[serde(flatten)]
     _other: serde_json::Value,
 }
@@ -113,6 +123,8 @@ impl MediaServer for Client {
             series,
             episode,
             season,
+            user_id: session.user.id,
+            user_name: session.user.title,
         })
     }
 }
@@ -137,7 +149,12 @@ mod test {
                         "grandparentKey": "path/to/series",
                         "index": 5,
                         "parentIndex": 3,
-                        "type": "episode"
+                        "type": "episode",
+                        "user": {
+                            "id": "1",
+                            "title": "user",
+                            "thumb": "ignore"
+                        }
                     }]
                 }
             }
@@ -187,6 +204,8 @@ mod test {
             series: Series::Tvdb(1234),
             episode: 5,
             season: 3,
+            user_id: "1".to_string(),
+            user_name: "user".to_string(),
         });
 
         assert_eq!(message, Some(message_expect));
@@ -228,7 +247,12 @@ mod test {
                                     "grandparentKey": "path/to/series",
                                     "index": 5,
                                     "parentIndex": 3,
-                                    "type": "episode"
+                                    "type": "episode",
+                                    "user": {
+                                        "id": "1",
+                                        "title": "user",
+                                        "thumb": "ignore"
+                                    }
                                 }
                             ]
                         }
@@ -253,6 +277,8 @@ mod test {
             series: Series::Tvdb(1234),
             episode: 5,
             season: 3,
+            user_id: "1".to_string(),
+            user_name: "user".to_string(),
         });
 
         assert_eq!(message, Some(message_expect));
@@ -280,7 +306,12 @@ mod test {
                                     "grandparentKey": "invalid",
                                     "index": 5,
                                     "parentIndex": 3,
-                                    "type": "episode"
+                                    "type": "episode",
+                                    "user": {
+                                        "id": "1",
+                                        "title": "user",
+                                        "thumb": "ignore"
+                                    }
                                 }
                             ]
                         }
@@ -305,6 +336,8 @@ mod test {
             series: Series::Title("Test Show".to_string()),
             episode: 5,
             season: 3,
+            user_id: "1".to_string(),
+            user_name: "user".to_string(),
         });
 
         assert_eq!(message, Some(message_expect));

--- a/src/process.rs
+++ b/src/process.rs
@@ -222,6 +222,8 @@ mod test {
             series: Series::Title("TestShow".to_string()),
             episode: 7,
             season: 1,
+            user_id: "12345".to_string(),
+            user_name: "test".to_string(),
         }))
         .await?;
 
@@ -301,6 +303,8 @@ mod test {
             series: Series::Tvdb(5678),
             episode: 7,
             season: 1,
+            user_id: "12345".to_string(),
+            user_name: "test".to_string(),
         }))
         .await?;
 
@@ -392,6 +396,8 @@ mod test {
             series: Series::Title("TestShow".to_string()),
             episode: 1,
             season: 1,
+            user_id: "12345".to_string(),
+            user_name: "test".to_string(),
         }))
         .await?;
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -13,6 +13,7 @@ pub struct Actor {
     sonarr_client: sonarr::Client,
     seen: Seen,
     remaining_episodes: u8,
+    users: Vec<String>,
 }
 
 impl Actor {
@@ -21,21 +22,41 @@ impl Actor {
         sonarr_client: sonarr::Client,
         seen: Seen,
         remaining_episodes: u8,
+        users: Vec<String>,
     ) -> Self {
         Self {
             rx,
             sonarr_client,
             seen,
             remaining_episodes,
+            users,
         }
     }
 }
 
 impl Actor {
+    fn is_user_wanted(&self, np: &NowPlaying) -> bool {
+        if self.users.len() == 0 {
+            // Always match if we have no users in the list.
+            true
+        } else {
+            // Match either the user ID or user name.
+            self.users.contains(&np.user_id) || self.users.contains(&np.user_name)
+        }
+    }
+
     pub async fn process(&mut self) {
         while let Some(msg) = self.rx.recv().await {
             match msg {
                 Message::NowPlaying(np) => {
+                    if !self.is_user_wanted(&np) {
+                        debug!(
+                            now_playing = ?np,
+                            users = ?self.users,
+                            "ignoring session from unwanted user"
+                        );
+                        break;
+                    }
                     if let Err(e) = self.search_next(np).await {
                         error!(err = ?e, "Failed to process");
                     }
@@ -213,7 +234,7 @@ mod test {
         let (tx, rx) = mpsc::channel(1);
         let sonarr = crate::sonarr::Client::new(&server.url("/pathprefix"), "secret")?;
         tokio::spawn(async move {
-            super::Actor::new(rx, sonarr, crate::once::Seen::default(), 2)
+            super::Actor::new(rx, sonarr, crate::once::Seen::default(), 2, vec![])
                 .process()
                 .await;
         });
@@ -232,6 +253,196 @@ mod test {
         series_mock.assert_async().await;
         put_series_mock.assert_async().await;
         command_mock.assert_async().await;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn search_next_filter_users() -> Result<(), Box<dyn std::error::Error>> {
+        let server = httpmock::MockServer::start_async().await;
+
+        let series_mock = server
+            .mock_async(|when, then| {
+                when.path("/pathprefix/api/v3/series");
+                then.json_body(serde_json::json!(
+                    [{
+                            "id": 1234,
+                            "title": "TestShow",
+                            "tvdbId": 5678,
+                            "monitored": false,
+                            "monitorNewItems": "all",
+                            "seasons": [{
+                                "seasonNumber": 1,
+                                "monitored": true,
+                                "statistics": {
+                                    "sizeOnDisk": 9000,
+                                    "episodeCount": 8,
+                                    "totalEpisodeCount": 8,
+                                }
+                            },{
+                                "seasonNumber": 2,
+                                "monitored": false,
+                                "statistics": {
+                                    "sizeOnDisk": 9000,
+                                    "episodeCount": 0,
+                                    "totalEpisodeCount": 8,
+                                }
+                            }]
+                        }
+                    ]
+                ));
+            })
+            .await;
+
+        let put_series_mock = server
+            .mock_async(|when, then| {
+                when.path("/pathprefix/api/v3/series/1234")
+                    .method(PUT)
+                    .json_body(serde_json::json!(
+                        {
+                            "id": 1234,
+                            "title": "TestShow",
+                            "tvdbId": 5678,
+                            "monitored": true,
+                            "monitorNewItems": "all",
+                            "seasons": [{
+                                "seasonNumber": 1,
+                                "monitored": true,
+                                "statistics": {
+                                    "sizeOnDisk": 9000,
+                                    "episodeCount": 8,
+                                    "totalEpisodeCount": 8,
+                                }
+                            },{
+                                "seasonNumber": 2,
+                                "monitored": true,
+                                "statistics": {
+                                    "sizeOnDisk": 9000,
+                                    "episodeCount": 0,
+                                    "totalEpisodeCount": 8,
+                                }
+                            }]
+                        }
+                    ));
+                then.json_body(json!({}));
+            })
+            .await;
+
+        let command_mock = server
+            .mock_async(|when, then| {
+                when.path("/pathprefix/api/v3/command")
+                    .method(POST)
+                    .json_body(json!({
+                        "name": "SeasonSearch",
+                        "seriesId": 1234,
+                        "seasonNumber": 2,
+                    }));
+                then.json_body(json!({}));
+            })
+            .await;
+
+        let (tx, rx) = mpsc::channel(3);
+        let sonarr = crate::sonarr::Client::new(&server.url("/pathprefix"), "secret")?;
+        tokio::spawn(async move {
+            super::Actor::new(
+                rx,
+                sonarr,
+                crate::once::Seen::default(),
+                2,
+                vec!["test".to_string(), "12345".to_string()],
+            )
+            .process()
+            .await;
+        });
+
+        // Valid user ID
+        tx.send(Message::NowPlaying(NowPlaying {
+            series: Series::Title("TestShow".to_string()),
+            episode: 7,
+            season: 1,
+            user_id: "12345".to_string(),
+            user_name: "other".to_string(),
+        }))
+        .await?;
+        // Valid username
+        tx.send(Message::NowPlaying(NowPlaying {
+            series: Series::Title("TestShow".to_string()),
+            episode: 7,
+            season: 1,
+            user_id: "67890".to_string(),
+            user_name: "test".to_string(),
+        }))
+        .await?;
+        // Invalid
+        tx.send(Message::NowPlaying(NowPlaying {
+            series: Series::Title("TestShow".to_string()),
+            episode: 7,
+            season: 1,
+            user_id: "67890".to_string(),
+            user_name: "unknown".to_string(),
+        }))
+        .await?;
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        // We expect 2 requests to be made for the series search - one for the
+        // valid user ID and one for the valid user name.
+        series_mock.assert_hits_async(2).await;
+        // But we only expect a single request to add the season and run a
+        // search.
+        put_series_mock.assert_async().await;
+        command_mock.assert_async().await;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn search_next_skips_unwanted_users() -> Result<(), Box<dyn std::error::Error>> {
+        let server = httpmock::MockServer::start_async().await;
+        let series_mock = server
+            .mock_async(|when, _| {
+                when.path("/pathprefix/api/v3/series");
+            })
+            .await;
+        let put_series_mock = server
+            .mock_async(|when, _| {
+                when.path("/pathprefix/api/v3/series/1234").method(PUT);
+            })
+            .await;
+        let command_mock = server
+            .mock_async(|when, _| {
+                when.path("/pathprefix/api/v3/command").method(POST);
+            })
+            .await;
+
+        let (tx, rx) = mpsc::channel(1);
+        let sonarr = crate::sonarr::Client::new(&server.url("/pathprefix"), "secret")?;
+        tokio::spawn(async move {
+            super::Actor::new(
+                rx,
+                sonarr,
+                crate::once::Seen::default(),
+                2,
+                vec!["test".to_string()],
+            )
+            .process()
+            .await;
+        });
+
+        tx.send(Message::NowPlaying(NowPlaying {
+            series: Series::Title("Some Unknown Show".to_string()),
+            episode: 79,
+            season: 40,
+            user_id: "12345".to_string(),
+            user_name: "unwanted".to_string(),
+        }))
+        .await?;
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        series_mock.assert_hits_async(0).await;
+        put_series_mock.assert_hits_async(0).await;
+        command_mock.assert_hits_async(0).await;
 
         Ok(())
     }
@@ -294,7 +505,7 @@ mod test {
         let (tx, rx) = mpsc::channel(1);
         let sonarr = crate::sonarr::Client::new(&server.url("/pathprefix"), "secret")?;
         tokio::spawn(async move {
-            super::Actor::new(rx, sonarr, crate::once::Seen::default(), 2)
+            super::Actor::new(rx, sonarr, crate::once::Seen::default(), 2, vec![])
                 .process()
                 .await;
         });
@@ -387,7 +598,7 @@ mod test {
         let (tx, rx) = mpsc::channel(1);
         let sonarr = crate::sonarr::Client::new(&server.url("/pathprefix"), "secret")?;
         tokio::spawn(async move {
-            super::Actor::new(rx, sonarr, crate::once::Seen::default(), 2)
+            super::Actor::new(rx, sonarr, crate::once::Seen::default(), 2, vec![])
                 .process()
                 .await;
         });


### PR DESCRIPTION
The idea is users can pass in a comma-separated list of user IDs (static/auto-generated) and user names. We then check against the list before processing a `NowPlaying` item. If both the user ID and user name do not match any in the list, we skip processing the entry.

Tested:

```
[nix-shell:~/repos/prefetcharr]$ cargo test
   Compiling prefetcharr v0.7.4 (/home/aksiksi/repos/prefetcharr)
    Finished test [unoptimized + debuginfo] target(s) in 5.35s
     Running unittests src/main.rs (target/debug/deps/prefetcharr-fa9a8069da698fc5)

running 28 tests
test media_server::embyfin::test::bad_url ... ok
test once::test::different_season ... ok
test once::test::different_series ... ok
test once::test::prune_old ... ok
test media_server::embyfin::test::single_session ... ok
test once::test::twice ... ok
test media_server::plex::test::single_session ... ok
test media_server::plex::test::skip_invalid_sessions ... ok
test media_server::plex::test::name_fallback ... ok
test media_server::embyfin::test::skip_invalid_sessions ... ok
test media_server::embyfin::test::jellyfin_auth ... ok
test media_server::embyfin::test::name_fallback_emby ... ok
test sonarr::test::auth ... ok
test media_server::embyfin::test::emby_auth ... ok
test sonarr::test::put_series ... ok
test sonarr::test::series_emtpy ... ok
test sonarr::test::search_season ... ok
test sonarr::test::series_multiple ... ok
test sonarr::test::series_parse_missing_statistics ... ok
test sonarr::test::series_skip_malformed_series ... ok
test sonarr::test::series_v3 ... ok
test once::test::touch ... ok
test media_server::embyfin::test::interval ... ok
test process::test::monitor ... ok
test process::test::pilot ... ok
test process::test::search_next_filter_users ... ok
test process::test::search_next ... ok
test process::test::search_next_skips_unwanted_users ... ok

test result: ok. 28 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.53s
```