### PR TITLE
Adds aired date checks to searches

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,96 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  push:
+    branches: [ "latest" ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "latest" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
+        with:
+          cosign-release: 'v2.2.4'
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,6 +1250,7 @@ dependencies = [
  "serde",
  "serde_json",
  "test-log",
+ "time",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ rust-version = "1.88.0"
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env", "string"] }
 futures = { version = "0.3.31", default-features = false, features = ["std"] }
+time = { version = "0.3", features = ["parsing", "formatting"] }
 reqwest = { version = "0", default-features = false, features = ["charset", "http2", "json", "query", "rustls"] }
 rustls = { version = "0.23.23", default-features = false }
 rustls-platform-verifier = "0.7"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ services:
         append_to_queue = false  # Experimental: Append upcoming episodes to the player's active queue.
                                  # Not supported by all clients. Not compatible with Tautulli.
         connection_retries = 6   # Number of retries for the initial connection probing
+        check_aired = false       # Skip episodes that haven't aired yet (uses Sonarr airDate)
 
         [media_server]
         type = "Jellyfin"                       # `Jellyfin`, `Emby`, `Plex` or `Tautulli`
@@ -70,6 +71,16 @@ command-line flag. For the Docker container, provide the entire configuration
 via the `PREFETCHARR_CONFIG` environment variable.
 A complete example can be found in the installation instructions for
 `docker-compose` above.
+
+### Configuration Options
+
+#### `check_aired`
+
+When `check_aired` is enabled (`true`), _prefetcharr_ will only prefetch episodes
+that have already aired according to their `airDate` field in Sonarr. This prevents
+attempting to download episodes that haven't been released yet. When disabled
+(`false`, the default), all missing episodes are prefetched regardless of their
+air date. Episodes without an `airDate` field are always considered to have aired.
 
 ### API keys
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,6 +70,9 @@ pub struct Config {
     /// Append upcoming episodes to the active player queue
     #[serde(default)]
     pub append_to_queue: bool,
+    /// Check if episodes have aired before prefetching (disabled by default)
+    #[serde(default)]
+    pub check_aired: bool,
     #[serde(default)]
     pub legacy: bool,
 }
@@ -112,6 +115,7 @@ impl From<LegacyArgs> for Config {
             request_seasons: true,
             connection_retries,
             append_to_queue: false,
+            check_aired: false,
             legacy: true,
         }
     }

--- a/src/fake_sonarr.rs
+++ b/src/fake_sonarr.rs
@@ -123,14 +123,22 @@ pub fn make_season(number: i32, monitored: bool, fully_aired: bool) -> Value {
 }
 
 pub fn make_episode(id: i32, series_id: i32, season: i32, episode: i32, has_file: bool) -> Value {
-    json!({
+    make_episode_with_airdate(id, series_id, season, episode, has_file, None)
+}
+
+pub fn make_episode_with_airdate(id: i32, series_id: i32, season: i32, episode: i32, has_file: bool, air_date: Option<&str>) -> Value {
+    let mut episode = json!({
         "id": id,
         "seriesId": series_id,
         "seasonNumber": season,
         "episodeNumber": episode,
         "hasFile": has_file,
         "monitored": false,
-    })
+    });
+    if let Some(date) = air_date {
+        episode["airDate"] = json!(date);
+    }
+    episode
 }
 
 async fn probe() -> &'static str {

--- a/src/main.rs
+++ b/src/main.rs
@@ -225,6 +225,7 @@ async fn run(config: Config) -> anyhow::Result<()> {
         config.prefetch_num,
         config.request_seasons,
         config.sonarr.exclude_tag,
+        config.check_aired,
         queue,
         has_pending,
         pending_ttl,

--- a/src/process.rs
+++ b/src/process.rs
@@ -33,6 +33,7 @@ pub struct Actor {
     prefetch_num: usize,
     request_seasons: bool,
     exclude_tag: Option<sonarr::Tag>,
+    check_aired: bool,
     queue: Option<Arc<dyn Queue + Send + Sync>>,
     pending: HashMap<String, Pending>,
     has_pending: Arc<AtomicBool>,
@@ -48,6 +49,7 @@ impl Actor {
         prefetch_num: usize,
         request_seasons: bool,
         exclude_tag: Option<String>,
+        check_aired: bool,
         queue: Option<Arc<dyn Queue + Send + Sync>>,
         has_pending: Arc<AtomicBool>,
         pending_ttl: Duration,
@@ -60,6 +62,7 @@ impl Actor {
             prefetch_num,
             request_seasons,
             exclude_tag,
+            check_aired,
             queue,
             pending: HashMap::new(),
             has_pending,
@@ -152,7 +155,7 @@ impl Actor {
         if episodes.len() < self.prefetch_num {
             info!("Not as many episodes announced, monitor new items instead");
             self.sonarr_client
-                .monitor_unannounced_episodes(&mut series)
+                .monitor_unannounced_episodes(&mut series, self.check_aired)
                 .await?;
         } else if !series.monitored {
             series.monitored = true;
@@ -160,6 +163,14 @@ impl Actor {
         }
 
         let missing_episodes: Vec<_> = episodes.into_iter().filter(|e| !e.has_file).collect();
+        
+        // Filter out episodes that haven't aired if check_aired is enabled
+        let missing_episodes: Vec<_> = if self.check_aired {
+            missing_episodes.into_iter().filter(|e| e.can_prefetch(true)).collect()
+        } else {
+            missing_episodes
+        };
+        
         let pairs: Vec<EpisodeRef> = missing_episodes
             .iter()
             .map(|e| EpisodeRef::new(e.season_number, e.episode_number))
@@ -187,7 +198,7 @@ impl Actor {
             for season_num in season_numbers {
                 if let Err(err) = self
                     .sonarr_client
-                    .search_season(&mut series, season_num)
+                    .search_season(&mut series, season_num, self.check_aired)
                     .await
                 {
                     error!("skip searching for season {season_num}: {err:#}");
@@ -364,6 +375,7 @@ mod test {
             prefetch_num,
             false,
             None,
+            false,
             Some(queue as Arc<dyn Queue + Send + Sync>),
             has_pending,
             pending_ttl,
@@ -394,7 +406,7 @@ mod test {
     }
 
     fn actor(fake: &FakeSonarr, prefetch_num: usize, request_seasons: bool) -> super::Actor {
-        actor_with_tag(fake, prefetch_num, request_seasons, None)
+        actor_with_tag(fake, prefetch_num, request_seasons, None, false)
     }
 
     fn actor_with_tag(
@@ -402,6 +414,7 @@ mod test {
         prefetch_num: usize,
         request_seasons: bool,
         exclude_tag: Option<String>,
+        check_aired: bool,
     ) -> super::Actor {
         let (_tx, rx) = mpsc::channel(1);
         let sonarr = crate::sonarr::Client::new(fake.url(), "secret").unwrap();
@@ -412,6 +425,7 @@ mod test {
             prefetch_num,
             request_seasons,
             exclude_tag,
+            check_aired,
             None,
             Arc::new(AtomicBool::new(false)),
             Duration::from_secs(3600),
@@ -683,7 +697,7 @@ mod test {
         fake.add_series(series);
         fake.add_episodes(default_episodes());
 
-        actor_with_tag(&fake, 2, true, Some("no-prefetch".to_string()))
+        actor_with_tag(&fake, 2, true, Some("no-prefetch".to_string()), false)
             .prefetch(NowPlaying {
                 series: Series::Title("TestShow".to_string()),
                 episode: 7,
@@ -706,7 +720,7 @@ mod test {
         fake.add_series(default_series());
         fake.add_episodes(default_episodes());
 
-        actor_with_tag(&fake, 1, true, Some("no-prefetch".to_string()))
+        actor_with_tag(&fake, 1, true, Some("no-prefetch".to_string()), false)
             .prefetch(NowPlaying {
                 series: Series::Title("TestShow".to_string()),
                 episode: 7,
@@ -729,7 +743,7 @@ mod test {
         fake.add_series(series);
         fake.add_episodes(default_episodes());
 
-        actor_with_tag(&fake, 1, true, Some("no-prefetch".to_string()))
+        actor_with_tag(&fake, 1, true, Some("no-prefetch".to_string()), false)
             .prefetch(NowPlaying {
                 series: Series::Title("TestShow".to_string()),
                 episode: 7,
@@ -1030,6 +1044,130 @@ mod test {
 
         // No has_pending observable here, but no panic either.
         // The Sonarr search still happened, and that's covered by other tests.
+        Ok(())
+    }
+
+    // When check_aired is enabled, episodes with future air dates are not prefetched
+    #[tokio::test]
+    #[test_log::test]
+    async fn check_aired_skips_future_episodes() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::fake_sonarr::make_episode_with_airdate;
+        
+        let fake = FakeSonarr::start().await;
+        fake.add_series(default_series());
+        
+        // Create episodes where s01e08 has a future air date
+        let mut eps = vec![];
+        for s in 1..=2 {
+            for e in 1..=8 {
+                let air_date = if s == 1 && e == 8 {
+                    Some("2099-01-01T00:00:00Z") // Future date
+                } else {
+                    None // No air date or past date
+                };
+                eps.push(make_episode_with_airdate(s * 10 + e, 1234, s, e, false, air_date));
+            }
+        }
+        fake.add_episodes(eps);
+
+        // Test with check_aired enabled
+        let mut actor = actor_with_tag(&fake, 2, false, None, true);
+        actor.prefetch(NowPlaying {
+            series: Series::Title("TestShow".to_string()),
+            episode: 7,
+            season: 1,
+            ..np_default()
+        })
+        .await?;
+
+        // s01e08 has a future air date, so it should not be monitored or searched
+        assert!(!fake.episode(18)["monitored"].as_bool().unwrap());
+        // s02e01 should still be processed (no future air date)
+        assert!(fake.episode(21)["monitored"].as_bool().unwrap());
+        
+        Ok(())
+    }
+
+    // When check_aired is disabled, episodes with future air dates are still prefetched
+    #[tokio::test]
+    #[test_log::test]
+    async fn check_aired_disabled_processes_all() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::fake_sonarr::make_episode_with_airdate;
+        
+        let fake = FakeSonarr::start().await;
+        fake.add_series(default_series());
+        
+        // Create episodes where s01e08 has a future air date
+        let mut eps = vec![];
+        for s in 1..=2 {
+            for e in 1..=8 {
+                let air_date = if s == 1 && e == 8 {
+                    Some("2099-01-01T00:00:00Z") // Future date
+                } else {
+                    None // No air date or past date
+                };
+                eps.push(make_episode_with_airdate(s * 10 + e, 1234, s, e, false, air_date));
+            }
+        }
+        fake.add_episodes(eps);
+
+        // Test with check_aired disabled (default)
+        let mut actor = actor_with_tag(&fake, 2, false, None, false);
+        actor.prefetch(NowPlaying {
+            series: Series::Title("TestShow".to_string()),
+            episode: 7,
+            season: 1,
+            ..np_default()
+        })
+        .await?;
+
+        // Both episodes should be monitored and searched when check_aired is disabled
+        assert!(fake.episode(18)["monitored"].as_bool().unwrap());
+        assert!(fake.episode(21)["monitored"].as_bool().unwrap());
+        
+        Ok(())
+    }
+
+    // When check_aired is enabled with request_seasons, unaired episodes in fully aired
+    // seasons are NOT monitored during season search
+    #[tokio::test]
+    #[test_log::test]
+    async fn check_aired_with_season_search() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::fake_sonarr::make_episode_with_airdate;
+        
+        let fake = FakeSonarr::start().await;
+        let mut series = default_series();
+        // Make season 1 fully aired (no next_airing)
+        series["seasons"][1] = make_season(1, false, true);
+        fake.add_series(series);
+        
+        // Create episodes where s01e08 has a future air date
+        let mut eps = vec![];
+        for e in 1..=8 {
+            let air_date = if e == 8 {
+                Some("2099-01-01T00:00:00Z") // Future date
+            } else {
+                None // No air date or past date
+            };
+            eps.push(make_episode_with_airdate(10 + e, 1234, 1, e, false, air_date));
+        }
+        fake.add_episodes(eps);
+
+        // Test with check_aired enabled and request_seasons enabled
+        let mut actor = actor_with_tag(&fake, 2, true, None, true);
+        actor.prefetch(NowPlaying {
+            series: Series::Title("TestShow".to_string()),
+            episode: 7,
+            season: 1,
+            ..np_default()
+        })
+        .await?;
+
+        // s01e08 has a future air date, so it should NOT be monitored even with season search
+        assert!(!fake.episode(18)["monitored"].as_bool().unwrap());
+        // s01e07 should be monitored (no future air date)
+        assert!(fake.episode(17)["monitored"].as_bool().unwrap());
+        
         Ok(())
     }
 }

--- a/src/sonarr.rs
+++ b/src/sonarr.rs
@@ -241,7 +241,7 @@ impl Client {
 
     // Make sure all newly announced episodes will be monitored.
     // https://forums.sonarr.tv/t/season-monitor-toggle-option-that-doesnt-change-the-existing-episode-state/30098/9
-    pub async fn monitor_unannounced_episodes(&self, series: &mut SeriesResource) -> Result<()> {
+    pub async fn monitor_unannounced_episodes(&self, series: &mut SeriesResource, check_aired: bool) -> Result<()> {
         // Make series eligible for monitoring checks
         series.monitored = true;
 
@@ -255,7 +255,19 @@ impl Client {
 
         if let Some(last_season) = series.seasons.last() {
             // Apply monitoring but restore episode state
-            let original_episodes = self.episodes_season(series, last_season).await?;
+            let mut original_episodes = self.episodes_season(series, last_season).await?;
+            // When check_aired is enabled, only monitor episodes that can be prefetched
+            // When disabled, monitor all episodes (original behavior)
+            if check_aired {
+                for e in &mut original_episodes {
+                    // Only monitor episodes that can be prefetched (have valid past air dates)
+                    e.monitored = e.can_prefetch(true);
+                }
+            } else {
+                for e in &mut original_episodes {
+                    e.monitored = true;
+                }
+            }
             self.put_series(series).await?;
             self.update_episode_monitoring(&original_episodes).await?;
         } else {
@@ -281,6 +293,7 @@ impl Client {
         &self,
         series: &mut SeriesResource,
         season_num: i32,
+        check_aired: bool,
     ) -> Result<serde_json::Value> {
         info!(num = season_num, "Searching season");
 
@@ -291,7 +304,9 @@ impl Client {
         if season.monitored {
             let mut season_episodes = self.episodes_season(series, season).await?;
             for e in &mut season_episodes {
-                e.monitored = true;
+                if !check_aired || e.can_prefetch(true) {
+                    e.monitored = true;
+                }
             }
             self.update_episode_monitoring(&season_episodes).await?;
         }
@@ -384,6 +399,66 @@ pub struct EpisodeResource {
     pub monitored: bool,
     #[serde(flatten)]
     other: serde_json::Value,
+}
+
+impl EpisodeResource {
+    /// Get the air date string, trying airDateUtc first (RFC3339 format), then airDate
+    fn get_air_date_str(&self) -> Option<&str> {
+        // Try airDateUtc first as it's in proper RFC3339 format
+        self.other.get("airDateUtc")
+            .and_then(|v| v.as_str())
+            .or_else(|| {
+                // Fall back to airDate
+                self.other.get("airDate")
+                    .and_then(|v| v.as_str())
+            })
+    }
+
+    /// Check if the episode has aired based on its airDate field
+    pub fn has_aired(&self) -> bool {
+        let air_date_str = self.get_air_date_str();
+        
+        match air_date_str {
+            None => true, // No air date info, assume aired
+            Some(date_str) => {
+                // Parse ISO 8601/RFC3339 date string
+                if let Ok(air_date) = time::OffsetDateTime::parse(date_str, &time::format_description::well_known::Rfc3339) {
+                    let now = time::OffsetDateTime::now_utc();
+                    air_date <= now
+                } else {
+                    // If parsing fails, assume it has aired
+                    true
+                }
+            }
+        }
+    }
+    
+    /// Check if the episode can be prefetched based on air date and check_aired setting
+    /// When check_aired is true, only prefetch episodes with valid past/future air dates
+    /// that have already aired. Episodes without air dates are excluded.
+    /// When check_aired is false, all episodes can be prefetched (original behavior).
+    pub fn can_prefetch(&self, check_aired: bool) -> bool {
+        if !check_aired {
+            return true;
+        }
+        
+        // When check_aired is true, only prefetch episodes with valid air dates that have aired
+        let air_date_str = self.get_air_date_str();
+        
+        match air_date_str {
+            None => false, // No air date info, don't prefetch when check_aired is true
+            Some(date_str) => {
+                // Parse ISO 8601/RFC3339 date string
+                if let Ok(air_date) = time::OffsetDateTime::parse(date_str, &time::format_description::well_known::Rfc3339) {
+                    let now = time::OffsetDateTime::now_utc();
+                    air_date <= now
+                } else {
+                    // If parsing fails, don't prefetch (we can't verify the air date)
+                    false
+                }
+            }
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -770,7 +845,7 @@ mod test {
             })
             .await;
 
-        client.search_season(&mut series, 1).await?;
+        client.search_season(&mut series, 1, false).await?;
 
         series_mock.assert_async().await;
         command_mock.assert_async().await;
@@ -846,7 +921,7 @@ mod test {
 
         let client = super::Client::new(&server.url("/pathprefix"), "secret")?;
 
-        client.search_season(&mut series, 1).await?;
+        client.search_season(&mut series, 1, false).await?;
 
         episodes_mock.assert_async().await;
         monitor_mock.assert_async().await;
@@ -1189,5 +1264,67 @@ mod test {
             other: Value::Null,
         };
         assert!(season.is_fully_aired());
+    }
+
+    // Episode with no airDate field is considered to have aired
+    #[test]
+    fn episode_has_aired_no_airdate() {
+        let episode = EpisodeResource {
+            id: 1,
+            season_number: 1,
+            episode_number: 1,
+            has_file: false,
+            monitored: false,
+            other: Value::Null,
+        };
+        assert!(episode.has_aired());
+    }
+
+    // Episode with past airDate is considered to have aired
+    #[test]
+    fn episode_has_aired_past_date() {
+        let mut other = serde_json::Map::new();
+        other.insert("airDate".to_string(), json!("2020-01-01T00:00:00Z"));
+        let episode = EpisodeResource {
+            id: 1,
+            season_number: 1,
+            episode_number: 1,
+            has_file: false,
+            monitored: false,
+            other: Value::Object(other),
+        };
+        assert!(episode.has_aired());
+    }
+
+    // Episode with future airDate is not considered to have aired
+    #[test]
+    fn episode_not_aired_future_date() {
+        let mut other = serde_json::Map::new();
+        other.insert("airDate".to_string(), json!("2099-01-01T00:00:00Z"));
+        let episode = EpisodeResource {
+            id: 1,
+            season_number: 1,
+            episode_number: 1,
+            has_file: false,
+            monitored: false,
+            other: Value::Object(other),
+        };
+        assert!(!episode.has_aired());
+    }
+
+    // Episode with invalid airDate format is considered to have aired
+    #[test]
+    fn episode_has_aired_invalid_date() {
+        let mut other = serde_json::Map::new();
+        other.insert("airDate".to_string(), json!("invalid-date"));
+        let episode = EpisodeResource {
+            id: 1,
+            season_number: 1,
+            episode_number: 1,
+            has_file: false,
+            monitored: false,
+            other: Value::Object(other),
+        };
+        assert!(episode.has_aired());
     }
 }


### PR DESCRIPTION
Stops prefetcharr searching for episodes that have not aired yet, for cases where the series has bad season consistency. American Dad and Futurama being a prime examples.

Enabled via check_aired = true in config. Defaults to disabled.


Tidied up the commits, the container is being generated here for testing - ghcr.io/poag/prefetcharr:latest
Apologies for the quality of the last attempt :)